### PR TITLE
Warn on parsing failures; support `redirect_from: url`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          registry-url: 'https://npm.pkg.github.com'
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://npm.pkg.github.com'
 
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN  }}

--- a/src/getRedirects.ts
+++ b/src/getRedirects.ts
@@ -12,8 +12,7 @@ export async function getRedirects(
   srcDir: string,
   getSlug: (filePath: string) => string,
   command: 'dev' | 'build' | 'preview',
-  logger,
-  }
+  logger
 ) {
   let redirects: Redirects = {}
 

--- a/src/getRedirects.ts
+++ b/src/getRedirects.ts
@@ -12,7 +12,7 @@ export async function getRedirects(
   srcDir: string,
   getSlug: (filePath: string) => string,
   command: 'dev' | 'build' | 'preview',
-  logger
+  logger: { warn: (msg: string) => void }
 ) {
   let redirects: Redirects = {}
 

--- a/src/getRedirects.ts
+++ b/src/getRedirects.ts
@@ -12,7 +12,8 @@ export async function getRedirects(
   srcDir: string,
   getSlug: (filePath: string) => string,
   command: 'dev' | 'build' | 'preview',
-  logger: any }
+  logger,
+  }
 ) {
   let redirects: Redirects = {}
 
@@ -31,10 +32,9 @@ export async function getRedirects(
     redirectFrom = redirectFrom.filter(redirect => {
       if (isValidDomainRelativePath(redirect)) {
         return true
-      } else {
-        logger.warn(`Invalid redirect path: ${redirect} in file: ${file}`)
-        return false
       }
+      logger.warn(`Invalid redirect path: ${redirect} in file: ${file}`)
+      return false
     })
 
     const isExcluded = command === 'build' && frontmatter?.draft === true

--- a/src/getRedirects.ts
+++ b/src/getRedirects.ts
@@ -3,19 +3,42 @@ import type { Redirects } from '.'
 import { createRedirect } from './createRedirect.js'
 import { getMarkdownFrontmatter } from './utils.js'
 
+function isValidDomainRelativePath(path: string): boolean {
+  return path.startsWith('/') && !path.includes('://')
+}
+
 export async function getRedirects(
   files: string[],
   srcDir: string,
   getSlug: (filePath: string) => string,
-  command: 'dev' | 'build' | 'preview'
+  command: 'dev' | 'build' | 'preview',
+  logger: any }
 ) {
   let redirects: Redirects = {}
 
   for (const file of files) {
     const frontmatter = await getMarkdownFrontmatter(path.join(srcDir, file))
-    const redirectFrom: string[] = frontmatter?.redirect_from
+    let redirectFrom: string[] = []
+
+    if (typeof frontmatter?.redirect_from === 'string') {
+      redirectFrom = [frontmatter.redirect_from]
+    } else if (Array.isArray(frontmatter?.redirect_from)) {
+      redirectFrom = frontmatter.redirect_from
+    } else if (frontmatter?.redirect_from) {
+      logger.warn(`Unexpected type for redirect_from in file: ${file}`)
+    }
+
+    redirectFrom = redirectFrom.filter(redirect => {
+      if (isValidDomainRelativePath(redirect)) {
+        return true
+      } else {
+        logger.warn(`Invalid redirect path: ${redirect} in file: ${file}`)
+        return false
+      }
+    })
+
     const isExcluded = command === 'build' && frontmatter?.draft === true
-    if (!frontmatter || !redirectFrom || isExcluded) continue
+    if (!frontmatter || !redirectFrom.length || isExcluded) continue
 
     const postSlug = frontmatter.slug || getSlug(file)
     if (!postSlug) continue

--- a/src/getRedirects.ts
+++ b/src/getRedirects.ts
@@ -4,7 +4,7 @@ import { createRedirect } from './createRedirect.js'
 import { getMarkdownFrontmatter } from './utils.js'
 
 function isValidDomainRelativePath(path: string): boolean {
-  return path.startsWith('/') && !path.includes('://')
+  return !path.includes('://') && !path.includes(' ') && !path.includes('\n')
 }
 
 export async function getRedirects(
@@ -20,12 +20,14 @@ export async function getRedirects(
     const frontmatter = await getMarkdownFrontmatter(path.join(srcDir, file))
     let redirectFrom: string[] = []
 
-    if (typeof frontmatter?.redirect_from === 'string') {
-      redirectFrom = [frontmatter.redirect_from]
-    } else if (Array.isArray(frontmatter?.redirect_from)) {
-      redirectFrom = frontmatter.redirect_from
-    } else if (frontmatter?.redirect_from) {
-      logger.warn(`Unexpected type for redirect_from in file: ${file}`)
+    if (frontmatter?.redirect_from){
+      if (typeof frontmatter?.redirect_from === 'string') {
+        redirectFrom = [frontmatter.redirect_from]
+      } else if (Array.isArray(frontmatter?.redirect_from)) {
+        redirectFrom = frontmatter.redirect_from
+      } else {
+        logger.warn(`Unexpected type ${typeof frontmatter?.redirect_from} for redirect_from in file: ${file}`)
+      }
     }
 
     redirectFrom = redirectFrom.filter(redirect => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import fs from 'node:fs'
 import type { AstroIntegration } from 'astro'
 import { getRedirects } from './getRedirects.js'
 import { getMarkdownFiles, getSlugFromFilePath, writeJson } from './utils.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,8 @@ export async function initPlugin(
       markdownFiles,
       _contentDirPath,
       _getSlug,
-      command
+      command,
+      logger
     )
     if (!redirects || !Object.keys(redirects).length) {
       logger.warn('No redirects found in markdown files')

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,9 @@ export async function initPlugin(
 
     updateConfig({ redirects })
 
+    if (!fs.existsSync(config.cacheDir.pathname)) {
+      fs.mkdirSync(config.cacheDir.pathname, { recursive: true })
+    }
     const redirectFilePath = path.join(
       config.cacheDir.pathname, // Default is ./node_modules/.astro/
       'redirect_from.json'

--- a/test/__fixtures__/markdown/posts/hello-once.md
+++ b/test/__fixtures__/markdown/posts/hello-once.md
@@ -1,0 +1,3 @@
+---
+redirect_from: /hello-once
+---

--- a/test/redirects.test.ts
+++ b/test/redirects.test.ts
@@ -3,6 +3,8 @@ import { createRedirect } from '../src/createRedirect'
 import { getRedirects } from '../src/getRedirects'
 import { getMarkdownFiles, getSlugFromFilePath } from '../src/utils'
 
+
+
 describe('getRedirects', async () => {
   // handling this more as an integration test
   const srcDir = './test/__fixtures__/markdown'
@@ -13,7 +15,8 @@ describe('getRedirects', async () => {
       files,
       srcDir,
       getSlugFromFilePath,
-      'build'
+      'build',
+      console
     )
     expect(result).toBeInstanceOf(Object)
     expect(result).toStrictEqual({

--- a/test/redirects.test.ts
+++ b/test/redirects.test.ts
@@ -23,6 +23,7 @@ describe('getRedirects', async () => {
       '/hello-astro-old': '/hello-astroooooo',
       '/hello-astro-old-234837': '/hello-astroooooo',
       '/hello-world-old': '/posts/hello-world',
+      "/hello-once": "/posts/hello-once",
       '/hello-world-old-234837': '/posts/hello-world',
       '/hello-markdown-old': '/hello-markdown',
       '/hello-markdown-old-234837': '/hello-markdown'

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -12,7 +12,7 @@ describe('getMarkdownFiles', () => {
   it('should return an array of markdown files from the given directory', async () => {
     const files = await getMarkdownFiles('./test/__fixtures__/markdown')
     expect(files).toBeInstanceOf(Array)
-    expect(files).toHaveLength(4)
+    expect(files).toHaveLength(5)
   })
 })
 


### PR DESCRIPTION
You'll want to squash this for sure; just used github's editor. Includes tests.  Fixes #152 

Creates node_modules/.astro folder if missing, which isn't created by astro 4. Fixes strings being coerced into arrays and mangled into single character redirects.