### PR TITLE
Convert URL.pathname to proper File Path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import url from 'node:url'
 import type { AstroIntegration } from 'astro'
 import { getRedirects } from './getRedirects.js'
 import { getMarkdownFiles, getSlugFromFilePath, writeJson } from './utils.js'
@@ -47,11 +48,13 @@ export async function initPlugin(
 
     updateConfig({ redirects })
 
-    if (!fs.existsSync(config.cacheDir.pathname)) {
-      fs.mkdirSync(config.cacheDir.pathname, { recursive: true })
+    const cacheDirPath = url.fileURLToPath(config.cacheDir)
+
+    if (!fs.existsSync(cacheDirPath)) {
+      fs.mkdirSync(cacheDirPath, { recursive: true })
     }
     const redirectFilePath = path.join(
-      config.cacheDir.pathname, // Default is ./node_modules/.astro/
+      cacheDirPath, // Default is ./node_modules/.astro/
       'redirect_from.json'
     )
     await writeJson(redirectFilePath, redirects)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs'
+import path from 'node:path'
+import url from 'node:url'
 import { describe, expect, it, vi } from 'vitest'
 import * as redirects from '../src/getRedirects'
 import astroRedirectFrom, { type HookOptions, initPlugin } from '../src/index'
@@ -10,10 +12,14 @@ const mockLogger = {
   error: vi.fn()
 }
 
+const cacheDirPath = url.pathToFileURL(
+  path.resolve('node_modules/.astro/')
+).href
+
 const hookOptionsMock = {
   logger: mockLogger,
   config: {
-    cacheDir: new URL('file://node_modules/.astro/')
+    cacheDir: new URL(cacheDirPath)
   },
   command: 'dev',
   updateConfig: vi.fn()

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import { describe, expect, it, vi } from 'vitest'
 import * as redirects from '../src/getRedirects'
 import astroRedirectFrom, { type HookOptions, initPlugin } from '../src/index'
@@ -12,7 +13,7 @@ const mockLogger = {
 const hookOptionsMock = {
   logger: mockLogger,
   config: {
-    cacheDir: { pathname: './node_modules/.astro/' }
+    cacheDir: new URL('file://node_modules/.astro/')
   },
   command: 'dev',
   updateConfig: vi.fn()
@@ -53,6 +54,9 @@ describe('initPlugin', () => {
 
     const writeJsonSpy = vi.spyOn(utils, 'writeJson')
     writeJsonSpy.mockImplementation(() => Promise.resolve())
+
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+    vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined)
 
     await initPlugin(hookOptionsMock)
 


### PR DESCRIPTION
Could not get this plugin to work on Windows and I got the following error:
```
11:47:01 [ERROR] [redirect-from] ENOENT: no such file or directory, mkdir 'C:\C:\dev\docs\node_modules\.astro'
```
Seems like `config.cacheDir.pathname` is used directly but this is unfortunatly not a valid file path in Windows.
The value `config.cacheDir` is a URL and pathname for me in this case is `\C:\dev\docs\node_modules\.astro`, which isn't correct since it starts with a leading backslash.

I added a conversion to a proper file path with with [url.fileURLToPath](https://nodejs.org/api/url.html#urlfileurltopathurl-options) and now it works as expected.

Was unfortunatly not able to run the the npm scripts since they seemed to be expecting a unix environment.